### PR TITLE
Update title and schedule

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,7 @@ pilot: false
 # Most workshops don't use extra pages. More information about extra
 # pages are included in the README:
 # https://github.com/carpentries/workshop-template#creating-extra-pages
-title: "2024-11-07-Philipps-University-Marburg-Library-Carpentries-Online"
+title: "Library Carpentry"
 
 #------------------------------------------------------------
 # Incubator workshop settings (only relevant for workshops teaching a lesson

--- a/_includes/lc/schedule.html
+++ b/_includes/lc/schedule.html
@@ -3,7 +3,7 @@
     <h3>Day 1</h3>
     <table class="table table-striped">
       <tr> <td>Before Starting</td>  <td><a href="{{ site.pre_survey }}{{ site.github.project_title }}" target="_blank" rel="noopener noreferrer">Pre-workshop survey</a></td> </tr>
-      <tr> <td>09:00</td>  <td><a href="https://librarycarpentry.org/lc-overview/">Jargon Busting, A Computational Approach, Introduction to Working with Data (Regular Expressions)</a></td> </tr>
+      <tr> <td>09:00</td>  <td><a href="https://librarycarpentry.org/lc-spreadsheets">Tidy Data</a></td> </tr>
       <tr> <td>10:30</td>  <td>Morning break</td> </tr>
       <tr> <td>12:00</td>  <td>Lunch break</td> </tr>
       <tr> <td>13:00</td>  <td><a href="https://librarycarpentry.org/lc-shell/">The Unix Shell</a></td> </tr>


### PR DESCRIPTION
- Updates the workshop title to "Library Carpentry"
- Adjusts the schedule to reflect that we will teach the [Tidy Data for Librarians](https://librarycarpentry.github.io/lc-spreadsheets/) lesson first, rather than the Library Carpentry Overview, which has been deprecated.